### PR TITLE
Fix runtime error when negative LPU and some error occurred

### DIFF
--- a/src/Asm2.f
+++ b/src/Asm2.f
@@ -299,10 +299,7 @@ C                                                  TO  SM
                IEQ = MEEN(I)
                IF (IEQ.EQ.0)   GO TO 400
                IF (IEQ.LT.0)   GO TO 360
-               IF (IEQ.ne.JEQ) GO TO 350
-               SM(ieq,jeq) = SM(ieq,jeq) + (TTCC(JP)+TTCC(JP))*EM(I,J)
-               GO TO 400
-  350          SM(ieq,jeq) = SM(ieq,jeq) + TTCC(JP)*EM(I,J)
+               SM(ieq,jeq) = SM(ieq,jeq) + TTCC(JP)*EM(I,J)
                SM(jeq,ieq) = SM(jeq,ieq) + TTCC(JP)*EM(J,I)
                GO TO 400
 C

--- a/src/SPR/sprfc1.f
+++ b/src/SPR/sprfc1.f
@@ -256,7 +256,9 @@ C     ----------------------------------------------------
          ENDIF
          CALL SPRER1 ( 40, 'SPRFC1', NUMNEG, SUPEQT, LIERR, LPU, IERR )
          MSPAR(27) = SUPEQT
-         IF ( LIERR .EQ. -30 ) WRITE(LPU,600) TOL, ABS(TOL(2)/TOL(3))
+         IF ( LIERR .EQ. -30 .AND. LPU.GE.0) THEN
+            WRITE(LPU,600) TOL, ABS(TOL(2)/TOL(3))
+         ENDIF
       ELSE IF ( NUMNEG .GT. 0 ) THEN
          IERR = 3
          CALL SPRER1 ( 60, 'SPRFC1', 0, SUPEQT, NUMNEG, LPU, IERR )

--- a/src/SPR/sprfc2.f
+++ b/src/SPR/sprfc2.f
@@ -249,7 +249,9 @@ C     ----------------------------------------------------
          ENDIF
          CALL SPRER1 ( 40, 'SPRFC2', NUMNEG, SUPEQT, LIERR, LPU, IERR )
          MSPAR(27) = SUPEQT
-         IF ( LIERR .EQ. -30 ) WRITE(LPU,600) TOL, TOL(2)/ABS(TOL(3))
+         IF ( LIERR .EQ. -30 .AND. LPU.GE.0) THEN
+            WRITE(LPU,600) TOL, TOL(2)/ABS(TOL(3))
+         ENDIF
       ENDIF
 
       MSPAR(26) = NUMNEG

--- a/src/SPR/sprfc3.f
+++ b/src/SPR/sprfc3.f
@@ -282,6 +282,7 @@ C     END OF MODULE SPRFC3
       SUBROUTINE   SPRF3N   ( N     , DCOR  , LPU    )
       INTEGER                 N     , LPU   , I
       DOUBLE PRECISION        DCOR(2,N)
+      IF (LPU .LT. 0) RETURN
       DO I = 1, N
          IF (DCOR(1,I) .LT. 0.0D0) WRITE(LPU,610) I,DCOR(1,I)
       END DO
@@ -294,6 +295,7 @@ C     END OF MODULE SPRFC3
       SUBROUTINE   SPRF3P   ( N     , NSING , TOL   , DCOR  , LPU    )
       INTEGER                 N     , NSING , LPU   , I     , J
       DOUBLE PRECISION        TOL   , DCOR(2,N)
+      IF (LPU .LT. 0) RETURN
       WRITE(LPU,600) TOL, NSING
       DO I = 1, N
          IF (DCOR(2,I) .NE. 0.0D0) WRITE(LPU,610) I,(DCOR(J,I),J=1,2)
@@ -361,7 +363,7 @@ C     END OF MODULE SPRFC3
             RHS(I,J) = 0.0D0
   100    CONTINUE
   200 CONTINUE
-      WRITE(LPU,600)
+      IF (LPU.GE.0) WRITE(LPU,600)
       RETURN
   600 FORMAT(5X,'THE ABOVE EQUATIONS ARE AUTOMATICALLY SUPPRESSED'/)
       END


### PR DESCRIPTION
Trying to print to a negative unit number causes run-time crash. The idea was to suppress all print when it was negative, but it seems these cases slipped when implementing that.